### PR TITLE
RHW 14.1

### DIFF
--- a/dist/webpack-assets.json
+++ b/dist/webpack-assets.json
@@ -1,1 +1,0 @@
-{"css/main":{"css":"/assets/css/main.css","js":"/assets/css/main.js"},"css/ckeditor5":{"css":"/assets/css/ckeditor5.css","js":"/assets/css/ckeditor5.js"},"js/airtable-list-builder":{"js":"/assets/js/airtable-list-builder.js"}}

--- a/gsb_research_hub_subtheme.theme
+++ b/gsb_research_hub_subtheme.theme
@@ -113,31 +113,52 @@ function gsb_research_hub_subtheme_preprocess_field(&$variables) {
 // Alter the results of the people page.
 function gsb_research_hub_subtheme_views_pre_render(&$view) {
   if ($view->id() === 'taxonomy_term_pages' && $view->current_display == 'people_terms') {
-    $rows = $view->result;
 
+    // Get the Taxonomy Term IDs
+    $levelTerms = \Drupal::entityQuery('taxonomy_term')
+              ->condition('vid', 'su_shared_tags')
+              ->condition('name', 'People - Level', 'STARTS_WITH')
+              ->sort('name', 'ASC')
+              ->execute();
+
+    // Reset the index
+    $levelTerms = array_values($levelTerms);
+
+    // Determine the sort order.
     $newSort = array();
-    foreach ($rows as $key => $row) {
+    foreach ($view->result as $key => $row) {
       $personInfo = $row->_relationship_entities['reverse__node__su_person_type_group'];
+      $personTags = $personInfo->get('su_shared_tags')->getValue();
+
       $personDetails = array(
         'key' => $key,
-        'name' =>$personInfo->get('su_person_first_name')->getValue()[0]['value'] . ' ' . $personInfo->get('su_person_last_name')->getValue()[0]['value'],
+        'name' =>$personInfo->get('su_person_last_name')->getValue()[0]['value'] . ' ' . $personInfo->get('su_person_first_name')->getValue()[0]['value'],
+        'data_name' => $row->taxonomy_term_field_data_name,
+        'level' => count($levelTerms),
       );
-      // Assign groups depending on whether the title has faculty director in it.
-      if (str_contains($personInfo->get('su_person_short_title')->getValue()[0]['value'], 'Faculty Director')) {
-        $personDetails['type'] = 'Faculty Director';
+
+      // Assign level
+      foreach ($levelTerms as $levelKey => $levelTid) {
+        if (array_filter($personTags, function($term) use ($levelTid) { return $term['target_id'] == $levelTid; })) {
+          $personDetails['level'] = $levelKey;
+        }
       }
-      else {
-        $personDetails['type'] = 'Other';
-      }
+
       $newSort[] = $personDetails;
     }
 
+    // Sort the list.
     $name = array_column($newSort, 'name');
-    $type = array_column($newSort, 'type');
-    array_multisort($type, SORT_ASC, $name, SORT_ASC, $newSort);
+    $level = array_column($newSort, 'level');
+    $data_name = array_column($newSort, 'data_name');
+    array_multisort($data_name, SORT_ASC, $level, SORT_ASC, $name, SORT_ASC, $newSort);
 
+    // Set the index to the new order.
     foreach ($newSort as $key => $sortRow) {
       $view->result[$sortRow['key']]->index = $key;
+      $newResult[$key] = $view->result[$sortRow['key']];
     }
+
+    $view->result = $newResult;
   }
 }

--- a/gsb_research_hub_subtheme.theme
+++ b/gsb_research_hub_subtheme.theme
@@ -109,3 +109,35 @@ function gsb_research_hub_subtheme_preprocess_field(&$variables) {
     $su_paragraph_row__bgcolor = $variables['items'][0]['content']['#markup'];
   }
 }
+
+// Alter the results of the people page.
+function gsb_research_hub_subtheme_views_pre_render(&$view) {
+  if ($view->id() === 'taxonomy_term_pages' && $view->current_display == 'people_terms') {
+    $rows = $view->result;
+
+    $newSort = array();
+    foreach ($rows as $key => $row) {
+      $personInfo = $row->_relationship_entities['reverse__node__su_person_type_group'];
+      $personDetails = array(
+        'key' => $key,
+        'name' =>$personInfo->get('su_person_first_name')->getValue()[0]['value'] . ' ' . $personInfo->get('su_person_last_name')->getValue()[0]['value'],
+      );
+      // Assign groups depending on whether the title has faculty director in it.
+      if (str_contains($personInfo->get('su_person_short_title')->getValue()[0]['value'], 'Faculty Director')) {
+        $personDetails['type'] = 'Faculty Director';
+      }
+      else {
+        $personDetails['type'] = 'Other';
+      }
+      $newSort[] = $personDetails;
+    }
+
+    $name = array_column($newSort, 'name');
+    $type = array_column($newSort, 'type');
+    array_multisort($type, SORT_ASC, $name, SORT_ASC, $newSort);
+
+    foreach ($newSort as $key => $sortRow) {
+      $view->result[$sortRow['key']]->index = $key;
+    }
+  }
+}

--- a/gsb_research_hub_subtheme.theme
+++ b/gsb_research_hub_subtheme.theme
@@ -121,6 +121,11 @@ function gsb_research_hub_subtheme_views_pre_render(&$view) {
               ->sort('name', 'ASC')
               ->execute();
 
+    // Exit immediately if there are no taxonomy terms.
+    if (!$levelTerms) {
+      return;
+    }
+
     // Reset the index
     $levelTerms = array_values($levelTerms);
 


### PR DESCRIPTION
Allow people to be sorted. 

Steps
1. Create 2 new shared tags. (People - Level 1, People - Level 2)
2. View one of the term pages where the people are listed. This does not affect the main listing.
<img width="1736" alt="Screenshot 2023-08-30 at 5 56 06 PM" src="https://github.com/gsb-library/gsb_research_hub_subtheme/assets/183711/add90214-648a-4b52-8e63-6bbbbbb83d18">

3. Edit a person and assign them the Level you would like them to be.
<img width="405" alt="Screenshot 2023-08-30 at 6 08 45 PM" src="https://github.com/gsb-library/gsb_research_hub_subtheme/assets/183711/9fdb8411-52ec-421c-be9c-b9e2b519e78e">

4. They will be sorted in order of level, then alphabetically by last name. You can see my record is now first.
<img width="1252" alt="Screenshot 2023-08-30 at 6 11 44 PM" src="https://github.com/gsb-library/gsb_research_hub_subtheme/assets/183711/ac65d9b1-c92b-437a-a15a-343a684d56aa">
