### PR TITLE
Fix error on people sorting pages due to changes in D10.

### DIFF
--- a/gsb_research_hub_subtheme.theme
+++ b/gsb_research_hub_subtheme.theme
@@ -116,6 +116,7 @@ function gsb_research_hub_subtheme_views_pre_render(&$view) {
 
     // Get the Taxonomy Term IDs
     $levelTerms = \Drupal::entityQuery('taxonomy_term')
+              ->accessCheck(TRUE)
               ->condition('vid', 'su_shared_tags')
               ->condition('name', 'People - Level', 'STARTS_WITH')
               ->sort('name', 'ASC')


### PR DESCRIPTION

Going to https://gsbresearchhub-test.sites.stanford.edu/people/research-labs-initiatives causes a 502 Bad Gateway message. This should fix that.