### PR TITLE
RHW-52: Add support for adding classes to arrays through the config.

### DIFF
--- a/dist/js/airtable-list-builder.js
+++ b/dist/js/airtable-list-builder.js
@@ -349,6 +349,7 @@ function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input ==
   // Apply the data to the template.
   function processTemplate(config, templateKey, data, allData) {
     var template = $('template#airtable-list-' + stringToCSSClass(templateKey) + '-template').html();
+    var settings = drupalSettings.gsbResearchHubSubtheme;
     if (template) {
       // Pull all of the tokens from the template.
       var tokens = [];
@@ -406,7 +407,12 @@ function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input ==
           } else {
             // If there is any field that needs formatting format it.
             if ("format" in config && token in config.format) {
-              content = formatString(config.format[token].type, config.format[token].options, content);
+              // Pull in any additional config passed in from the text area.
+              var additionalConfig = [];
+              if ("arrayFormatConfig" in settings && token in settings.arrayFormatConfig) {
+                additionalConfig = settings.arrayFormatConfig[token];
+              }
+              content = formatString(config.format[token].type, config.format[token].options, content, additionalConfig);
             }
             var fieldTemplate = $('template#airtable-list-' + stringToCSSClass(token) + '-template').html();
             if (fieldTemplate) {
@@ -435,7 +441,7 @@ function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input ==
   }
 
   // Formats a string into the given type.
-  function formatString(type, format, content) {
+  function formatString(type, format, content, additionalConfig) {
     var newContent = '';
     switch (type) {
       case 'Array':
@@ -448,7 +454,11 @@ function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input ==
             item = _step5.value;
             count++;
             var replacedContent = replaceToken(template, 'value', item);
-            replacedContent = replaceToken(replacedContent, 'class', stringToCSSClass(item));
+            var classes = stringToCSSClass(item);
+            if ("classMap" in additionalConfig && item in additionalConfig.classMap) {
+              classes += " " + additionalConfig.classMap[item];
+            }
+            replacedContent = replaceToken(replacedContent, 'class', classes);
             newContent += replacedContent;
             if (format.hasOwnProperty('separator') && count != content.length) {
               newContent += format.separator;

--- a/dist/webpack-assets.json
+++ b/dist/webpack-assets.json
@@ -1,1 +1,0 @@
-{"css/main":{"css":"/assets/css/main.css","js":"/assets/css/main.js"},"css/ckeditor5":{"css":"/assets/css/ckeditor5.css","js":"/assets/css/ckeditor5.js"},"js/airtable-list-builder":{"js":"/assets/js/airtable-list-builder.js"}}

--- a/gsb_research_hub_subtheme.theme
+++ b/gsb_research_hub_subtheme.theme
@@ -63,7 +63,13 @@ function gsb_research_hub_subtheme_preprocess_paragraph(&$variables) {
       ];
 
       $sl_env = theme_get_setting('gsb_research_hub_subtheme_sl_env', 'gsb_research_hub_subtheme');
-      $variables['#attached']['drupalSettings']['gsbResearchHubSubtheme'] = is_null($sl_env) ? $sl_env_conf['prod'] : $sl_env_conf[$sl_env];
+
+      $jsVars = is_null($sl_env) ? $sl_env_conf['prod'] : $sl_env_conf[$sl_env];
+      if (isset($jsonConfig['variables'])) {
+        $jsVars = array_merge($jsonConfig['variables'], $jsVars);
+      }
+
+      $variables['#attached']['drupalSettings']['gsbResearchHubSubtheme'] = $jsVars;
     }
   }
 }

--- a/src/js/airtable-list-builder.js
+++ b/src/js/airtable-list-builder.js
@@ -338,6 +338,7 @@
   // Apply the data to the template.
   function processTemplate(config, templateKey, data, allData) {
     var template = $('template#airtable-list-' + stringToCSSClass(templateKey) + '-template').html();
+    var settings = drupalSettings.gsbResearchHubSubtheme;
     if (template) {
       // Pull all of the tokens from the template.
       var tokens = [];
@@ -378,7 +379,13 @@
           else {
             // If there is any field that needs formatting format it.
             if ("format" in config && token in config.format) {
-              content = formatString(config.format[token].type, config.format[token].options, content);
+
+              // Pull in any additional config passed in from the text area.
+              var additionalConfig = [];
+              if ("arrayFormatConfig" in settings && token in settings.arrayFormatConfig) {
+                additionalConfig = settings.arrayFormatConfig[token];
+              }
+              content = formatString(config.format[token].type, config.format[token].options, content, additionalConfig);
             }
 
             var fieldTemplate = $('template#airtable-list-' + stringToCSSClass(token) + '-template').html();
@@ -409,7 +416,7 @@
   }
 
   // Formats a string into the given type.
-  function formatString(type, format, content) {
+  function formatString(type, format, content, additionalConfig) {
     var newContent = '';
     switch(type) {
       case 'Array':
@@ -418,7 +425,11 @@
         for (item of content) {
           count++;
           var replacedContent = replaceToken(template, 'value', item);
-          replacedContent = replaceToken(replacedContent, 'class', stringToCSSClass(item));
+          var classes = stringToCSSClass(item);
+          if ("classMap" in additionalConfig && item in additionalConfig.classMap) {
+            classes += " " + additionalConfig.classMap[item];
+          }
+          replacedContent = replaceToken(replacedContent, 'class', classes);
           newContent += replacedContent;
           if (format.hasOwnProperty('separator') && count != content.length) {
             newContent += format.separator;


### PR DESCRIPTION
In the config of the text area you can add a mapping that allows you to add classes to specific values in an array. 

Ex. 

```
{
    "type":"airtable", 
    "view": "training", 
    "variables": { 
        "arrayFormatConfig": {
            "categories": {
  	        "classMap":{ 
	            "Using Research Resources": "darc", 
  		    "Computing and Analytics": "library"
  	        }
            }
        }
    }
}
```

Where
categories = The array field name.
Using Research Resources = The name of the option.
darc = The class name